### PR TITLE
Support Ray RL lib submissions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setuptools.setup(
             'setuptools',
             'distro>=1',
             'gym<=0.21.0',
-            'jupyter>=1.0.0',
             'testresources',
             'inputs',
             'screeninfo',


### PR DESCRIPTION
Added the possibility to save the environment characteristics (more
specifically Observation and Action spaces) that usually require you to
open a connection with the engine.

Loading this info from file allows to avoid booting up the engine at
initialization of the Ray Algo and one just needs to provide the filepath
as done with config files with Stable Baselines.

When using the file, environment check is automatically deactivated.