### PR TITLE
Install wheel in build environment as a temporary fix to the new python build process

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.x"
+      - run: python3 -m pip install wheel==0.38.4
       - run: python3 -m pip install .["tests"]
       - run: pytest tests/test_gym_settings.py
       - run: pytest tests/test_wrappers_settings.py


### PR DESCRIPTION
@discordianfish do you think we also need to update something else for example in the image generation CICD? (cannot test it without cutting a release/publish something)